### PR TITLE
fix(examples): pin opa-wasm to 0.3.2 so pip install succeeds

### DIFF
--- a/examples/requirements.txt
+++ b/examples/requirements.txt
@@ -6,5 +6,5 @@ pandas>=2.0.0
 # For policy engine WASM examples
 wasmtime>=15.0.0
 pathlib>=1.0.1
-opa-wasm>=1.0.0
+opa-wasm>=0.3.2
 jsonlogic>=0.9.0 


### PR DESCRIPTION
pinned opa to 0.3.2 as version 1.0.0 doesnt exist yet